### PR TITLE
feat(sftp): Add configurable dirMode and fileMode

### DIFF
--- a/packages/balm-core/index.d.ts
+++ b/packages/balm-core/index.d.ts
@@ -189,6 +189,8 @@ export interface BalmFtpConfig {
   username?: string;
   password?: string;
   remotePath?: string;
+  dirMode?: string;
+  fileMode?: string;
 }
 
 export interface BalmConfig {

--- a/packages/balm-core/src/plugins/sftp.ts
+++ b/packages/balm-core/src/plugins/sftp.ts
@@ -312,7 +312,6 @@ function gulpSftp(options: LooseObject): any {
         (cb: Function) => {
           let d = fileDirs.pop() as string;
           mkDirCache[d] = true;
-          // Mdrake - TODO: use a default file permission instead of defaulting to 755
           if (
             remotePlatform &&
             remotePlatform.toLowerCase().indexOf('win') !== -1
@@ -324,7 +323,8 @@ function gulpSftp(options: LooseObject): any {
             if (exist) {
               cb();
             } else {
-              sftp.mkdir(d, { mode: '0755' }, (err: string) => {
+              const dirMode = options.dirMode || '0755';
+              sftp.mkdir(d, { mode: dirMode }, (err: string) => {
                 // REMOTE PATH
                 if (err) {
                   // Assuming that the directory exists here, silencing this error
@@ -342,10 +342,11 @@ function gulpSftp(options: LooseObject): any {
           });
         },
         () => {
+          const fileMode = options.fileMode || '0666';
           const stream = sftp.createWriteStream(finalRemotePath, {
             flags: 'w',
             encoding: null,
-            mode: '0666',
+            mode: fileMode,
             autoClose: true
           });
 


### PR DESCRIPTION
Fixes the hardcoded directory and file creation permissions in the SFTP plugin. It utilizes the options object to read `dirMode` and `fileMode` options and updates the type definitions accordingly. Backward compatibility is maintained.

---
*PR created automatically by Jules for task [9354299428229461705](https://jules.google.com/task/9354299428229461705) started by @elf-mouse*